### PR TITLE
Add AMD HIP and NVIDIA CUDA implementations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ add_subdirectory(kokkos)
 # Backend selection
 option(K6071_HIP "Compile HIP version" OFF)
 set(K6071_HIP ${K6071_ENABLE_HIP} CACHE BOOL "" FORCE)
+option(K6071_ENABLE_CUDA "Compile CUDA version" OFF)
+set(K6071_CUDA ${K6071_ENABLE_CUDA} CACHE BOOL "" FORCE)
+
 option(K6071_ENABLE_RIGHT "Use Iterate::Right" OFF)
 set(K6071_RIGHT ${K6071_ENABLE_RIGHT} CACHE BOOL "" FORCE)
 
@@ -75,4 +78,44 @@ if(K6071_HIP)
   target_link_libraries(hip utils)
 endif()
 
+if(K6071_CUDA)
+  enable_language(CUDA)
+
+  add_executable(cuda)
+  target_sources(cuda PRIVATE src/cuda.cu)
+  target_compile_features(cuda PRIVATE cxx_std_20)
+  set_target_properties(cuda PROPERTIES CXX_EXTENSIONS OFF)
+  set_target_properties(cuda PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+  if(K6071_RIGHT)
+    target_compile_definitions(cuda PRIVATE -DRIGHT)
+  endif()
+  if(K6071_CHECK_RES)
+    target_compile_definitions(cuda PRIVATE -DCHECK)
+  endif()
+  target_compile_options(
+    cuda
+    PRIVATE
+      -Wall
+      -Wextra
+      -Wpedantic
+      -Wshadow
+  )
+  target_link_libraries(cuda utils)
 endif()
+
+# add_executable(test)
+# target_sources(test PRIVATE src/test.cpp)
+# target_compile_features(test PRIVATE cxx_std_20)
+# set_target_properties(test PROPERTIES CXX_EXTENSIONS OFF)
+# if(K6071_RIGHT)
+#   target_compile_definitions(test PRIVATE -DRIGHT)
+# endif()
+# target_compile_options(
+#   test
+#   PRIVATE
+#     -Wall
+#     -Wextra
+#     -Wpedantic
+#     -Wshadow
+# )
+# target_link_libraries(test Kokkos::kokkos)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,3 +22,20 @@ target_compile_options(
     -Wshadow
 )
 target_link_libraries(k6071 Kokkos::kokkos)
+
+add_executable(hip6071)
+target_sources(hip6071 PRIVATE src/hip.cpp)
+target_compile_features(hip6071 PRIVATE cxx_std_20)
+set_target_properties(hip6071 PROPERTIES CXX_EXTENSIONS OFF)
+if(K6071_RIGHT)
+  target_compile_definitions(hip6071 PRIVATE -DRIGHT)
+endif()
+target_compile_options(
+  hip6071
+  PRIVATE
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wshadow
+)
+target_link_libraries(hip6071 Kokkos::kokkos)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,18 @@
 cmake_minimum_required(VERSION 3.23)
 project(K6071 LANGUAGES CXX)
 
+set(CMAKE_COLOR_DIAGNOSTICS ON)
+
 add_subdirectory(kokkos)
 
+# Backend selection
+option(K6071_HIP "Compile HIP version" OFF)
+set(K6071_HIP ${K6071_ENABLE_HIP} CACHE BOOL "" FORCE)
 option(K6071_ENABLE_RIGHT "Use Iterate::Right" OFF)
 set(K6071_RIGHT ${K6071_ENABLE_RIGHT} CACHE BOOL "" FORCE)
 
-option(K6071_ENABLE_CHECKS "Check that computed result is correct" OFF)
-set(K6071_CHECKS ${K6071_ENABLE_CHECKS} CACHE BOOL "" FORCE)
+option(K6071_ENABLE_CHECK_RES "Check that computed result is correct" OFF)
+set(K6071_CHECK_RES ${K6071_ENABLE_CHECK_RES} CACHE BOOL "" FORCE)
 
 add_library(utils INTERFACE)
 target_sources(
@@ -45,22 +50,26 @@ target_compile_options(
 )
 target_link_libraries(k6071 Kokkos::kokkos)
 
-add_executable(hip6071)
-target_sources(hip6071 PRIVATE src/hip.cpp)
-target_compile_features(hip6071 PRIVATE cxx_std_20)
-set_target_properties(hip6071 PROPERTIES CXX_EXTENSIONS OFF)
-if(K6071_RIGHT)
-  target_compile_definitions(hip6071 PRIVATE -DRIGHT)
+if(K6071_HIP)
+  add_executable(hip)
+  target_sources(hip PRIVATE src/hip.cpp)
+  target_compile_features(hip PRIVATE cxx_std_20)
+  set_target_properties(hip PROPERTIES CXX_EXTENSIONS OFF)
+  if(K6071_RIGHT)
+    target_compile_definitions(hip PRIVATE -DRIGHT)
+  endif()
+  if(K6071_CHECK_RES)
+    target_compile_definitions(hip PRIVATE -DCHECK)
+  endif()
+  target_compile_options(
+    hip
+    PRIVATE
+      -Wall
+      -Wextra
+      -Wpedantic
+      -Wshadow
+  )
+  target_link_libraries(hip utils)
 endif()
-if(K6071_CHECKS)
-  target_compile_definitions(hip6071 PRIVATE -DCHECK)
+
 endif()
-target_compile_options(
-  hip6071
-  PRIVATE
-    -Wall
-    -Wextra
-    -Wpedantic
-    -Wshadow
-)
-target_link_libraries(hip6071 utils)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,28 @@ add_subdirectory(kokkos)
 option(K6071_ENABLE_RIGHT "Use Iterate::Right" OFF)
 set(K6071_RIGHT ${K6071_ENABLE_RIGHT} CACHE BOOL "" FORCE)
 
+option(K6071_ENABLE_CHECKS "Check that computed result is correct" OFF)
+set(K6071_CHECKS ${K6071_ENABLE_CHECKS} CACHE BOOL "" FORCE)
+
+add_library(utils INTERFACE)
+target_sources(
+  utils
+  INTERFACE
+  FILE_SET HEADERS
+  BASE_DIRS ${PROJECT_SOURCE_DIR}/src
+  FILES src/utils.hpp
+)
+target_compile_features(utils INTERFACE cxx_std_20)
+set_target_properties(utils PROPERTIES CXX_EXTENSIONS OFF)
+target_compile_options(
+  utils
+  INTERFACE
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wshadow
+)
+
 add_executable(k6071)
 target_sources(k6071 PRIVATE src/kokkos.cpp)
 target_compile_features(k6071 PRIVATE cxx_std_20)
@@ -29,6 +51,9 @@ target_compile_features(hip6071 PRIVATE cxx_std_20)
 set_target_properties(hip6071 PROPERTIES CXX_EXTENSIONS OFF)
 if(K6071_RIGHT)
   target_compile_definitions(hip6071 PRIVATE -DRIGHT)
+endif()
+if(K6071_CHECKS)
+  target_compile_definitions(hip6071 PRIVATE -DCHECK)
 endif()
 target_compile_options(
   hip6071

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,22 +33,25 @@ target_compile_options(
     -Wshadow
 )
 
-add_executable(k6071)
-target_sources(k6071 PRIVATE src/kokkos.cpp)
-target_compile_features(k6071 PRIVATE cxx_std_20)
-set_target_properties(k6071 PROPERTIES CXX_EXTENSIONS OFF)
+add_executable(kok)
+target_sources(kok PRIVATE src/kokkos.cpp)
+target_compile_features(kok PRIVATE cxx_std_20)
+set_target_properties(kok PROPERTIES CXX_EXTENSIONS OFF)
 if(K6071_RIGHT)
-  target_compile_definitions(k6071 PRIVATE -DRIGHT)
+  target_compile_definitions(kok PRIVATE -DRIGHT)
+endif()
+if(K6071_CHECK_RES)
+  target_compile_definitions(kok PRIVATE -DCHECK)
 endif()
 target_compile_options(
-  k6071
+  kok
   PRIVATE
     -Wall
     -Wextra
     -Wpedantic
     -Wshadow
 )
-target_link_libraries(k6071 Kokkos::kokkos)
+target_link_libraries(kok Kokkos::kokkos utils)
 
 if(K6071_HIP)
   add_executable(hip)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,4 +63,4 @@ target_compile_options(
     -Wpedantic
     -Wshadow
 )
-target_link_libraries(hip6071 Kokkos::kokkos)
+target_link_libraries(hip6071 utils)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.23)
 project(K6071 LANGUAGES CXX)
 
+# Enable color for Ninja output
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 add_subdirectory(kokkos)
@@ -11,10 +12,12 @@ set(K6071_HIP ${K6071_ENABLE_HIP} CACHE BOOL "" FORCE)
 option(K6071_ENABLE_CUDA "Compile CUDA version" OFF)
 set(K6071_CUDA ${K6071_ENABLE_CUDA} CACHE BOOL "" FORCE)
 
+# Enable iteration with Layout Right (row-major) or not
 option(K6071_ENABLE_RIGHT "Use Iterate::Right" OFF)
 set(K6071_RIGHT ${K6071_ENABLE_RIGHT} CACHE BOOL "" FORCE)
 
-option(K6071_ENABLE_CHECK_RES "Check that computed result is correct" OFF)
+# Enable checking result
+option(K6071_ENABLE_CHECK_RES "Check that computed result is correct" ON)
 set(K6071_CHECK_RES ${K6071_ENABLE_CHECK_RES} CACHE BOOL "" FORCE)
 
 add_library(utils INTERFACE)
@@ -36,6 +39,7 @@ target_compile_options(
     -Wshadow
 )
 
+# Pure Kokkos reproducer
 add_executable(kok)
 target_sources(kok PRIVATE src/kokkos.cpp)
 target_compile_features(kok PRIVATE cxx_std_20)
@@ -56,6 +60,7 @@ target_compile_options(
 )
 target_link_libraries(kok Kokkos::kokkos utils)
 
+# If enabled, compile a pure HIP implementation
 if(K6071_HIP)
   add_executable(hip)
   target_sources(hip PRIVATE src/hip.cpp)
@@ -78,6 +83,7 @@ if(K6071_HIP)
   target_link_libraries(hip utils)
 endif()
 
+# If enabled, compile a pure CUDA implementation
 if(K6071_CUDA)
   enable_language(CUDA)
 
@@ -103,19 +109,20 @@ if(K6071_CUDA)
   target_link_libraries(cuda utils)
 endif()
 
-# add_executable(test)
-# target_sources(test PRIVATE src/test.cpp)
-# target_compile_features(test PRIVATE cxx_std_20)
-# set_target_properties(test PROPERTIES CXX_EXTENSIONS OFF)
-# if(K6071_RIGHT)
-#   target_compile_definitions(test PRIVATE -DRIGHT)
-# endif()
-# target_compile_options(
-#   test
-#   PRIVATE
-#     -Wall
-#     -Wextra
-#     -Wpedantic
-#     -Wshadow
-# )
-# target_link_libraries(test Kokkos::kokkos)
+# Test for understanding how MDRangePolicy and Iterate::* work.
+add_executable(test)
+target_sources(test PRIVATE src/test.cpp)
+target_compile_features(test PRIVATE cxx_std_20)
+set_target_properties(test PROPERTIES CXX_EXTENSIONS OFF)
+if(K6071_RIGHT)
+  target_compile_definitions(test PRIVATE -DRIGHT)
+endif()
+target_compile_options(
+  test
+  PRIVATE
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wshadow
+)
+target_link_libraries(test Kokkos::kokkos)

--- a/src/cuda.cu
+++ b/src/cuda.cu
@@ -1,0 +1,104 @@
+#include "utils.hpp"
+
+#include <cuda.h>
+
+#include <iostream>
+#include <vector>
+
+#ifdef RIGHT
+#warning Using `Iterate::Right`
+#endif
+
+template <class T>
+__global__ void gemm_kernel(T* A, T* B, T* C, size_t M, size_t N, size_t K) {
+#ifdef RIGHT
+  size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+  size_t j = blockIdx.y * blockDim.y + threadIdx.y;
+#else
+  size_t j = blockIdx.x * blockDim.x + threadIdx.x;
+  size_t i = blockIdx.y * blockDim.y + threadIdx.y;
+#endif
+
+  if (i < M && j < N) {
+    T tmp = 0.0;
+#ifdef RIGHT
+    for (size_t k = 0; k < K; ++k) {
+      tmp += A[k * M + i] * B[j * K + k];
+    }
+    C[j * M + i] = tmp;
+#else
+    for (size_t k = 0; k < K; ++k) {
+      tmp += A[i * K + k] * B[k * N + j];
+    }
+    C[i * N + j] = tmp;
+#endif
+  }
+}
+
+template <class T>
+auto gemm(T* A, size_t A_extent0, size_t A_extent1, T* B, size_t B_extent1, T* C, int T1, int T2) -> void {
+  size_t M = A_extent0;
+  size_t K = A_extent1;
+  size_t N = B_extent1;
+
+  dim3 block_dim(T2 > 0 ? T2 : 16, T1 > 0 ? T1 : 16);
+  dim3 grid_dim((N + block_dim.x - 1) / block_dim.x, (M + block_dim.y - 1) / block_dim.y);
+
+  gemm_kernel<T><<<grid_dim, block_dim>>>(A, B, C, M, N, K);
+}
+
+template <class T>
+auto benchmark(size_t N, size_t R, int T1, int T2) -> void {
+  size_t elems = N * N;
+  size_t bytes = elems * sizeof(T);
+  double flops = 2.0 * static_cast<double>(N * N * N * R);
+
+  std::vector<T> h_A(elems, 1);
+  std::vector<T> h_B(elems, 1);
+  std::vector<T> h_C(elems);
+
+  T* d_A{};
+  T* d_B{};
+  T* d_C{};
+  CUDA_CHECK(cudaMalloc((void**)&d_A, bytes));
+  CUDA_CHECK(cudaMalloc((void**)&d_B, bytes));
+  CUDA_CHECK(cudaMalloc((void**)&d_C, bytes));
+  CUDA_CHECK(cudaMemcpy(d_A, h_A.data(), bytes, cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_B, h_B.data(), bytes, cudaMemcpyHostToDevice));
+
+  gemm(d_A, N, N, d_B, N, d_C, T1, T2);
+  CUDA_CHECK(cudaDeviceSynchronize());
+  Timer timer;
+  for (size_t r = 0; r < R; r++) {
+    gemm(d_A, N, N, d_B, N, d_C, T1, T2);
+  }
+  CUDA_CHECK(cudaDeviceSynchronize());
+  double time = timer.seconds();
+
+  std::cout << "Flops: " << flops << ", Bytes: " << sizeof(T) << ", GFlop/s: " << flops / time * 1.0e-9 << "\n";
+
+  CUDA_CHECK(cudaMemcpy(h_C.data(), d_C, bytes, cudaMemcpyDeviceToHost));
+
+#ifdef CHECK
+  check_result(h_C.data(), N);
+#endif
+
+  CUDA_CHECK(cudaFree(d_A));
+  CUDA_CHECK(cudaFree(d_B));
+  CUDA_CHECK(cudaFree(d_C));
+}
+
+auto main(int argc, char* argv[]) -> int {
+  // Matrix dimensions
+  size_t N = argc > 1 ? static_cast<size_t>(std::stoi(argv[1])) : 4096;
+  // Benchmark repetitions
+  size_t R = argc > 2 ? static_cast<size_t>(std::stoi(argv[2])) : 11;
+  // Block sizes to use when running the HIP kernel
+  int T1 = argc > 3 ? std::stoi(argv[3]) : -1;
+  int T2 = argc > 4 ? std::stoi(argv[4]) : T1;
+
+  benchmark<double>(N, R, T1, T2);
+  benchmark<float>(N, R, T1, T2);
+
+  return 0;
+}

--- a/src/hip.cpp
+++ b/src/hip.cpp
@@ -1,0 +1,85 @@
+#include <Kokkos_Core.hpp>
+#include <hip/hip_runtime.h>
+
+#include <cmath>
+#include <iostream>
+
+#ifdef RIGHT
+#warning Using `Iterate::Right`
+#endif
+
+template <class T>
+__global__ void gemm_kernel(T* A, T* B, T* C, size_t M, size_t N, size_t K) {
+#ifdef RIGHT
+  size_t m = blockIdx.x * blockDim.x + threadIdx.x;
+  size_t n = blockIdx.y * blockDim.y + threadIdx.y;
+#else
+  size_t m = blockIdx.y * blockDim.y + threadIdx.y;
+  size_t n = blockIdx.x * blockDim.x + threadIdx.x;
+#endif
+
+  if (m < M && n < N) {
+    T tmp = 0.0;
+    for (size_t k = 0; k < K; ++k) {
+      tmp += A[m * K + k] * B[k * N + n];
+    }
+    C[m * N + n] = tmp;
+  }
+}
+
+template <class T>
+auto gemm(Kokkos::View<T**> A, Kokkos::View<T**> B, Kokkos::View<T**> C, int T1, int T2) -> void {
+  size_t M = A.extent(0);
+  size_t K = A.extent(1);
+  size_t N = B.extent(1);
+
+  dim3 block_dim(T2 > 0 ? T2 : 16, T1 > 0 ? T1 : 16);
+  dim3 grid_dim((N + block_dim.x - 1) / block_dim.x, (M + block_dim.y - 1) / block_dim.y);
+
+  gemm_kernel<T>
+    <<<grid_dim, block_dim, 0, hipStreamDefault>>>(
+      A.data(), B.data(), C.data(), M, N, K
+    );
+}
+
+template <class T>
+auto benchmark(size_t N, size_t R, int T1, int T2) -> void {
+  double flops = 2.0 * static_cast<double>(N * N * N * R);
+
+  Kokkos::View<T**> A("A", N, N);
+  Kokkos::View<T**> B("B", N, N);
+  Kokkos::View<T**> C("C", N, N);
+  Kokkos::deep_copy(A, 1);
+  Kokkos::deep_copy(B, 1);
+  Kokkos::deep_copy(C, 1);
+
+  gemm(A, B, C, T1, T2);
+  Kokkos::fence();
+  Kokkos::Timer timer;
+  for (size_t r = 0; r < R; r++) {
+    gemm(A, B, C, T1, T2);
+  }
+  Kokkos::fence();
+  double time = timer.seconds();
+
+  std::cout << "Flops: " << flops << ", Bytes: " << sizeof(T) << ", GFlop/s: " << flops / time * 1.0e-9 << "\n";
+}
+
+auto main(int argc, char* argv[]) -> int {
+  Kokkos::initialize(argc, argv);
+  {
+    size_t N = argc > 1 ? static_cast<size_t>(std::stoi(argv[1])) : 4096;
+    size_t R = argc > 2 ? static_cast<size_t>(std::stoi(argv[2])) : 11;
+    int T1   = argc > 3 ? std::stoi(argv[3]) : -1;
+    int T2   = argc > 4 ? std::stoi(argv[4]) : T1;
+
+    benchmark<double>(N, R, T1, T2);
+    benchmark<float>(N, R, T1, T2);
+#if KOKKOS_VERSION >= 30700
+    benchmark<Kokkos::Experimental::half_t>(N, R, T1, T2);
+#endif
+  }
+  Kokkos::finalize();
+
+  return 0;
+}

--- a/src/hip.cpp
+++ b/src/hip.cpp
@@ -1,7 +1,5 @@
-#include <Kokkos_Core.hpp>
-#include <hip/hip_runtime.h>
+#include "utils.hpp"
 
-#include <cmath>
 #include <iostream>
 
 #ifdef RIGHT
@@ -63,6 +61,9 @@ auto benchmark(size_t N, size_t R, int T1, int T2) -> void {
   double time = timer.seconds();
 
   std::cout << "Flops: " << flops << ", Bytes: " << sizeof(T) << ", GFlop/s: " << flops / time * 1.0e-9 << "\n";
+#ifdef CHECK
+  check_result(h_C.data(), N);
+#endif
 }
 
 auto main(int argc, char* argv[]) -> int {

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -1,0 +1,53 @@
+#include <Kokkos_Core.hpp>
+
+#include <cmath>
+#include <iostream>
+
+#ifdef RIGHT
+#warning Using `Iterate::Right`
+using Iterate = Kokkos::Rank<2, Kokkos::Iterate::Right, Kokkos::Iterate::Right>;
+#else
+using Iterate = Kokkos::Rank<2, Kokkos::Iterate::Left, Kokkos::Iterate::Left>;
+#endif
+
+template <class T>
+using V = Kokkos::View<T**, Kokkos::LayoutLeft>;
+
+template <class T>
+auto iter(V<T> A) -> void {
+  size_t M = A.extent(0);
+  size_t N = A.extent(1);
+  Kokkos::MDRangePolicy<Iterate> p({0, 0}, {M, N});
+  Kokkos::parallel_for(
+    "A", p,
+    #ifdef RIGHT
+    KOKKOS_LAMBDA(size_t j, size_t i) {
+    #else
+    KOKKOS_LAMBDA(size_t i, size_t j) {
+    #endif
+      Kokkos::printf("A(%d, %d) = %lf\n", i, j, A(i, j));
+    }
+  );
+}
+
+template <class T>
+auto benchmark(size_t N) -> void {
+  V<T> A("A", N, N);
+  for (size_t j = 0; j < N; ++j) {
+    for (size_t i = 0; i < N; ++i) {
+      A(i, j) = i * 10 + j;
+    }
+  }
+  iter(A);
+}
+
+auto main(int argc, char* argv[]) -> int {
+  Kokkos::initialize(argc, argv);
+  {
+    size_t N = argc > 1 ? static_cast<size_t>(std::stoi(argv[1])) : 4096;
+    benchmark<double>(N);
+  }
+  Kokkos::finalize();
+
+  return 0;
+}

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -21,6 +21,16 @@ constexpr int error_exit_code = -1;
     }                                                                                                                  \
   }
 
+#define CUDA_CHECK(condition)                                                                                          \
+  {                                                                                                                    \
+    cudaError_t const err = condition;                                                                                 \
+    if (err != cudaSuccess) {                                                                                          \
+      std::cerr << "CUDA Runtime error at: " << __FILE__ << ":" << __LINE__ << "\n"                                    \
+                << "  " << cudaGetErrorString(err) << "\n";                                                            \
+      std::exit(error_exit_code);                                                                                      \
+    }                                                                                                                  \
+  }
+
 class Timer {
 public:
   Timer() { start = std::chrono::high_resolution_clock::now(); }

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <hip/hip_runtime.h>
+
+#include <cassert>
+#include <chrono>
+#include <cstddef>
+
+constexpr int error_exit_code = -1;
+
+/**
+ * Checks if the provided error code is hipSuccess and if not, prints an error message to the standard error output and
+ * terminates the program with an error code.
+ **/
+#define HIP_CHECK(condition)                                                                                           \
+  {                                                                                                                    \
+    const hipError_t error = condition;                                                                                \
+    if (error != hipSuccess) {                                                                                         \
+      std::cerr << "An error encountered: \"" << hipGetErrorString(error) << "\" at " << __FILE__ << ':' << __LINE__   \
+                << std::endl;                                                                                          \
+      std::exit(error_exit_code);                                                                                      \
+    }                                                                                                                  \
+  }
+
+class Timer {
+public:
+  Timer() { start = std::chrono::high_resolution_clock::now(); }
+
+  auto seconds() -> double {
+    auto elapsed = std::chrono::high_resolution_clock::now() - start;
+    return std::chrono::duration_cast<std::chrono::duration<double>>(elapsed).count();
+  }
+
+private:
+  std::chrono::high_resolution_clock::time_point start;
+};
+
+template <class T>
+auto check_result(T const* C, size_t extent) -> void {
+  for (size_t i = 0; i < extent; ++i) {
+    for (size_t j = 0; j < extent; ++j) {
+      assert(C[i * extent + j] == 1);
+    }
+  }
+}


### PR DESCRIPTION
Add a pure HIP gemm kernel (still using Kokkos Views).

Not sure how to emulate Kokkos' `Iterate::Right` yet?

Sample output on AMD MI210 GPU:

- Iterate Left (HIP's default):
```
[user@host k6071]$ left/k6071
Flops: 1.51183e+12, Bytes: 8, GFlop/s: 444.801
Flops: 1.51183e+12, Bytes: 4, GFlop/s: 924.422
Flops: 1.51183e+12, Bytes: 2, GFlop/s: 1024.96

[user@host k6071]$ left/hip6071
Flops: 1.51183e+12, Bytes: 8, GFlop/s: 474.837
Flops: 1.51183e+12, Bytes: 4, GFlop/s: 985.778
Flops: 1.51183e+12, Bytes: 2, GFlop/s: 1010.05
```
- Iterate Right:
```
[user@host k6071]$ right/k6071
Flops: 1.51183e+12, Bytes: 8, GFlop/s: 83.038
Flops: 1.51183e+12, Bytes: 4, GFlop/s: 66.0029
Flops: 1.51183e+12, Bytes: 2, GFlop/s: 78.089

[user@host k6071]$ right/hip6071
Flops: 1.51183e+12, Bytes: 8, GFlop/s: 199.867
Flops: 1.51183e+12, Bytes: 4, GFlop/s: 236.408
Flops: 1.51183e+12, Bytes: 2, GFlop/s: 237.339
```

Pure HIP is faster when iterating Right, however I am not sure the implementations are equivalent.
Performance between Kokkos and HIP is comparable when iterating Left.